### PR TITLE
ido-init-completion-maps is obsolete and unnecessary since Emacs 25.1.

### DIFF
--- a/idomenu.el
+++ b/idomenu.el
@@ -68,7 +68,8 @@
   "Switch to a buffer-local tag from Imenu via Ido."
   (interactive)
   ;; ido initialization
-  (ido-init-completion-maps)
+  ;; (when (version< emacs-version "25.1")
+  ;;   (ido-init-completion-maps))
   (add-hook 'minibuffer-setup-hook 'ido-minibuffer-setup)
   (add-hook 'choose-completion-string-functions 'ido-choose-completion-string)
   (add-hook 'kill-emacs-hook 'ido-kill-emacs-hook)


### PR DESCRIPTION
Removed to prevent byte-compiler warning.